### PR TITLE
8 fix empty line bug

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24913,10 +24913,8 @@ const emptyCommit = {
 
 function parseCommit(string) {
     var messageParts = string.split("\n");
-    messageParts.pop();
+    if (messageParts[messageParts.length -1].length === 0) messageParts.pop();
     emptyLineIndexes = getEmptyLineIndexes(messageParts);
-    // console.log("Message Parts: " + messageParts);
-    // console.log("Empty Line: " + emptyLineIndexes);
     if (messageParts.filter(entry => entry.length > 0).length === 0) return emptyCommit;
     return {
         subject: getSubject(messageParts, emptyLineIndexes),

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "pre-commit": "ncc build index.js && npm run test"
   },
   "jest": {
     "collectCoverage": true,

--- a/src/commitParser.js
+++ b/src/commitParser.js
@@ -7,7 +7,7 @@ const emptyCommit = {
 
 function parseCommit(string) {
     var messageParts = string.split("\n");
-    messageParts.pop();
+    if (messageParts[messageParts.length -1].length === 0) messageParts.pop();
     emptyLineIndexes = getEmptyLineIndexes(messageParts);
     // console.log("Message Parts: " + messageParts);
     // console.log("Empty Line: " + emptyLineIndexes);

--- a/src/commitParser.js
+++ b/src/commitParser.js
@@ -9,8 +9,6 @@ function parseCommit(string) {
     var messageParts = string.split("\n");
     if (messageParts[messageParts.length -1].length === 0) messageParts.pop();
     emptyLineIndexes = getEmptyLineIndexes(messageParts);
-    // console.log("Message Parts: " + messageParts);
-    // console.log("Empty Line: " + emptyLineIndexes);
     if (messageParts.filter(entry => entry.length > 0).length === 0) return emptyCommit;
     return {
         subject: getSubject(messageParts, emptyLineIndexes),

--- a/tests/commitParser.test.js
+++ b/tests/commitParser.test.js
@@ -8,6 +8,7 @@ const singleLineBody = "test body in a single line\n";
 
 const issue = "Issue: #343\n";
 const signOff = "Signed Off By: test@test.com\n";
+const signOffNoNewLine = "Signed Off By: test@test.com";
 
 const correctSubject = subject.replace("\n", "");
 const correctMultiLineBody = multiLineBody.split("\n").slice(0, 2);
@@ -17,7 +18,7 @@ const correctSignOff = signOff.replace("\n", "");
  
 
 describe('Test creation of commit message object', () => {
-    test("Create a commit message object with full fields with multi line body", () => {
+    test("it should create a commit message object with full fields with multi line body", () => {
         const commitString = subject +
                             "\n" +
                             multiLineBody +
@@ -35,7 +36,7 @@ describe('Test creation of commit message object', () => {
         expect(commits[0].signOff).toEqual(correctSignOff);
     });
 
-    test("Create a commit message object with full fields with single line body", () => {
+    test("it should create a commit message object with full fields with single line body", () => {
         const commitString = subject +
                             "\n" +
                             singleLineBody +
@@ -51,6 +52,24 @@ describe('Test creation of commit message object', () => {
         expect(commits[0].body).toEqual(correctSingleLineBody);
         expect(commits[0].issue).toEqual(correctIssue);
         expect(commits[0].signOff).toEqual(correctSignOff);
+    });
+
+    test("it should create a commit message object with full fields without line break at end of commit", () => {
+        const commitString = subject +
+                            "\n" +
+                            singleLineBody +
+                            "\n" +
+                            issue + 
+                            "\n" +
+                            signOffNoNewLine;
+
+        const commits = createCommits(commitString);
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0].subject).toEqual(correctSubject);
+        expect(commits[0].body).toEqual(correctSingleLineBody);
+        expect(commits[0].issue).toEqual(correctIssue);
+        expect(commits[0].signOff).toEqual(signOffNoNewLine);
     });
 
     test("it should create commit object with correct fields when given multi paragraph body", () => {


### PR DESCRIPTION
Fix empty line bug by checking the end of the message parts to see if the last entry is empty. Also added npm run command which builds the compiled file and runs test.

Closes: https://github.com/julianGoh17/commit-reader/issues/8